### PR TITLE
ENH : 병사 등록시 나오는 Toast 메시지에서 이름의 값이 잘못들어가 있는 오류 수정

### DIFF
--- a/app/src/main/java/com/ponjohmnaimann/kookmobanuser/SharedPreferenceData.kt
+++ b/app/src/main/java/com/ponjohmnaimann/kookmobanuser/SharedPreferenceData.kt
@@ -30,7 +30,7 @@ class SharedPreferenceData(context: Context) {
 
     var name: String?
         get () = prefs.getString(prefKeyName, "이름을 입력하세요")
-        set(value) = prefs.edit().putString(name, value).apply()
+        set(value) = prefs.edit().putString(prefKeyName, value).apply()
 
     var serviceNumber: String?
         get () = prefs.getString(prefKeyServiceNumber, "군번을 입력하세요")


### PR DESCRIPTION
* prefs에 넣을때 키값이 prefKeyName이 아닌 name으로 설정되어 있는 오류  수정

![image](https://user-images.githubusercontent.com/32615702/96339161-bcfd7780-10cd-11eb-94ff-2d2ff82822fd.png)


Resolves #11